### PR TITLE
Additional tax information of invoice items

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ node_modules
 *.env
 .DS_Store
 package-lock.json
+.idea

--- a/README.md
+++ b/README.md
@@ -60,18 +60,21 @@ let myInvoice = new Invoice({
               , unit: "Hours"
               , quantity: 5
               , unitPrice: 2
+              , tax: 0.33
             }
           , {
                 description: "Another interesting task"
               , unit: "Hours"
               , quantity: 10
               , unitPrice: 3
+              , tax: 0.07
             }
           , {
                 description: "The most interesting one"
               , unit: "Hours"
               , quantity: 3
               , unitPrice: 5
+              , tax: 0
             }
         ]
     }

--- a/example/index.js
+++ b/example/index.js
@@ -28,24 +28,27 @@ let myInvoice = new Invoice({
             }
         }
       , tasks: [
-            {
-                description: "Some interesting task"
-              , unit: "Hours"
-              , quantity: 5
-              , unitPrice: 2
-            }
+          {
+            description: "Some interesting task"
+            , unit: "Hours"
+            , quantity: 5
+            , unitPrice: 2
+            , tax: 0.33
+          }
           , {
-                description: "Another interesting task"
-              , unit: "Hours"
-              , quantity: 10
-              , unitPrice: 3
-            }
+            description: "Another interesting task"
+            , unit: "Hours"
+            , quantity: 10
+            , unitPrice: 3
+            , tax: 0.07
+          }
           , {
-                description: "The most interesting one"
-              , unit: "Hours"
-              , quantity: 3
-              , unitPrice: 5
-            }
+            description: "The most interesting one"
+            , unit: "Hours"
+            , quantity: 3
+            , unitPrice: 5
+            , tax: 0
+          }
         ]
     }
   , seller: {

--- a/example/template/blocks/row.html
+++ b/example/template/blocks/row.html
@@ -3,10 +3,14 @@
     <td>{{description}}</td>
     <td>{{unit}}</td>
     <td class="text-right">{{quantity}}</td>
+    <td class="text-right">{{taxString}}%</td>
     <td class="text-right">{{unitPrice.main}}<br>
         {{unitPrice.secondary}}
     </td>
     <td class="text-right">{{amount.main}}<br>
         {{amount.secondary}}
+    </td>
+    <td class="text-right">{{amount.mainTaxed}}<br>
+        {{amount.secTaxed}}
     </td>
 </tr>

--- a/example/template/index.html
+++ b/example/template/index.html
@@ -130,13 +130,23 @@
                             (Cant.)
                         </th>
                         <th>
+                            <strong>Tax</strong><br>
+                            (Impôt)
+                        </th>
+                        <th>
                             <strong>Unit price.<br>
                                 –{{invoice.currency.main}}–
                             </strong><br>
                             –({{invoice.currency.secondary}})–
                         </th>
                         <th>
-                            <strong>Total Amount.<br>
+                            <strong>Total Amount. (Net)<br>
+                                –{{invoice.currency.main}}–
+                            </strong><br>
+                            –({{invoice.currency.secondary}})–
+                        </th>
+                        <th>
+                            <strong>Total Amount. (Gross)<br>
                                 –{{invoice.currency.main}}–
                             </strong><br>
                             –({{invoice.currency.secondary}})–
@@ -146,13 +156,17 @@
                 <tbody class="text-top">
                     {{{description_rows}}}
                     <tr>
-                        <td colspan="5" class="text-center">
+                        <td colspan="6" class="text-center">
                             <strong>Invoice Total –CHF– </strong><br>
                             (Valoare totală de plată factura curentă –RON–)
                         </td>
                         <td class="text-right">
                             <strong>{{total.main}}</strong><br>
                             ({{total.secondary}})
+                        </td>
+                        <td class="text-right">
+                            <strong>{{total.mainTax}}</strong><br>
+                            ({{total.secTax}})
                         </td>
                     </tr>
                 </tbody>

--- a/lib/index.js
+++ b/lib/index.js
@@ -92,6 +92,8 @@ module.exports = class NodeIce {
               , total: {
                     main: 0
                   , secondary: 0
+                  , mainTax: 0
+                  , secTax: 0
                 }
             }
           ;
@@ -117,19 +119,29 @@ module.exports = class NodeIce {
                     cTask.unitPrice.secondary = cTask.unitPrice.secondary.toFixed(2);
                 }
 
+                const mainAmount = cTask.unitPrice.main * cTask.quantity;
+                const secAmount = cTask.unitPrice.secondary * cTask.quantity;
+
                 // Build amount object
                 cTask.amount = {
-                    main: cTask.unitPrice.main * cTask.quantity
-                  , secondary: cTask.unitPrice.secondary * cTask.quantity
+                    main: mainAmount
+                  , secondary: secAmount
+                  , mainTaxed: mainAmount + (cTask.tax * mainAmount)
+                  , secTaxed: secAmount + (cTask.tax * secAmount)
                 };
 
                 // Sum the amount to the total
                 invoiceData.total.main += cTask.amount.main;
                 invoiceData.total.secondary += cTask.amount.secondary;
+                invoiceData.total.mainTax += cTask.amount.mainTaxed;
+                invoiceData.total.secTax += cTask.amount.secTaxed;
 
                 // Set the amount of this row
                 cTask.amount.main = cTask.amount.main.toFixed(2);
                 cTask.amount.secondary = cTask.amount.secondary.toFixed(2);
+                cTask.amount.mainTaxed = cTask.amount.mainTaxed.toFixed(2);
+                cTask.amount.secTaxed = cTask.amount.secTaxed.toFixed(2);
+                cTask.taxString = parseFloat(cTask.tax * 100).toFixed(0);
 
                 // Render HTML for the current row
                 invoiceData.description_rows += mustache.render(
@@ -140,6 +152,8 @@ module.exports = class NodeIce {
             // Set the total
             invoiceData.total.main  = invoiceData.total.main.toFixed(2);
             invoiceData.total.secondary = invoiceData.total.secondary.toFixed(2);
+            invoiceData.total.mainTax = invoiceData.total.mainTax.toFixed(2);
+            invoiceData.total.secTax = invoiceData.total.secTax.toFixed(2);
 
             // Render the invoice HTML fields
             invoiceHtml = mustache.render(templates.root, invoiceData);

--- a/package.json
+++ b/package.json
@@ -17,6 +17,10 @@
     "pdf"
   ],
   "author": "Ionică Bizău <bizauionica@gmail.com> (https://ionicabizau.net)",
+  "contributors": [
+    "Radu-Bogdan Croitoru <croitoruradubogdan@gmail.com> (https://github.com/radubogdan)",
+    "Jan Pedryc <jan.pedryc@gmail.com> (https://jan-pedryc.com)"
+  ],
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/IonicaBizau/nodeice/issues"


### PR DESCRIPTION
Added additional fields considering the **tax information of single items**. This package was ideal for my case - small, not over-complicated and somewhat nice. The only thing I was missing were the tax information.  
I hope this modification could help also others. Let me know what you think.   

---  

A preview:  

![nodice](https://user-images.githubusercontent.com/38433190/43680420-8b8b73ea-983a-11e8-806f-84c941eef1a1.png)
